### PR TITLE
Update B2260 documentation throughout

### DIFF
--- a/Downloads/AOSP.md
+++ b/Downloads/AOSP.md
@@ -1,5 +1,0 @@
-# Android Open Source Project (AOSP)
-
-Currently not available.
-
-**AOSP** is a mobile/tablet platform environment developer preview. This environment is primarily used to test applications/software developed remotely on a host computer using an assortment of IDE’s(integrated development environments) and SDK’s(software development kits).

--- a/Downloads/Debian.md
+++ b/Downloads/Debian.md
@@ -1,35 +1,16 @@
 # Debian
 
-**Debian Linux** is a desktop/window or console (command line) based development environment comprised of some basic programs and utilities. Development can happen directly on the board, and within the OS. While applications and programs can be built directly on the board, they can also be built remotely and cross-compiled for the particular system.
+**Debian Linux** is a desktop/window or console (command line) based development environment comprised of some basic programs and utilities. Development can happen directly on the board, and within the OS. While applications and programs can be built directly on the board, they can also be built remotely and cross-compiled for a particular system.
 
 ***
 
 ## SD Card image
 
-|   SD Card Image   |    [Desktop]() or [Developer]()     |
+|   SD Card Image   | Build Directory ([Latest](http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/) |
 |:------------------|:------------------------------------|
-|Release Notes:     |[Link]()                             |
+|  Debian (Alip)  |[Download](http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/b2260-jessie_alip_*.img.gz) |
+|  Debian (Developer)  |[Download](http://builds.96boards.org/snapshots/b2260/linaro/debian/latest/b2260-jessie_developer_*.img.gz) |
 
 Continue to [Installation page](../Installation/README.md)
 
 ***
-
-## Fastboot files
-
-|   Bootloader |                        |
-|:-------------|:-----------------------|
-| Comp 1       | [Download]()           |
-| Comp 2       | [Download]()           | 
-| Comp 3       | [Download]()           | 
-| Comp 4       | [Download]()           | 
-| Comp 5       | [Download]()           | 
-
-|   Boot image      |    [Download]()        |
-|:------------------|:-----------------------|
-|Release Notes:     |[Link]()                |
-
-|   Rootfs image    |    [Desktop]()                    |
-|:------------------|:----------------------------------|
-|Release Notes:     |[Link]()                           |
-
-Continue to [Installation page](../Installation/README.md)

--- a/Downloads/OpenEmbedded.md
+++ b/Downloads/OpenEmbedded.md
@@ -1,0 +1,23 @@
+# OpenEmbedded
+
+**OpenEmbedded** is a software framework used for creating Linux distributions aimed for, but not restricted to, embedded devices. Below are pre-built console and desktop images. If desired, these images can be recreated by following the build from source instructions found [here](https://github.com/Linaro/documentation/blob/master/Reference-Platform/CECommon/OE.md) (Note: this link will take you to the Linaro Github)
+
+***
+
+**Jethro**
+
+|   SD Card image    |  Build Folder ([RPB](http://builds.96boards.org/snapshots/reference-platform/openembedded/jethro/stih410-b2260/rpb/latest/)/[RPB-Wayland](http://builds.96boards.org/snapshots/reference-platform/openembedded/jethro/stih410-b2260/rpb-wayland/latest/)) |
+|:------------------|:-----------------------|
+| RPB    | ([Desktop](http://builds.96boards.org/snapshots/reference-platform/openembedded/jethro/stih410-b2260/rpb/latest/rpb-desktop-image-stih410-b2260-*.stimg)/[Console](http://builds.96boards.org/snapshots/reference-platform/openembedded/jethro/stih410-b2260/rpb/latest/rpb-console-image-stih410-b2260-*.stimg)) |
+| RPB-Wayland | ([Desktop](http://builds.96boards.org/snapshots/reference-platform/openembedded/jethro/stih410-b2260/rpb-wayland/latest/rpb-weston-image-stih410-b2260-*.stimg)/[Console](http://builds.96boards.org/snapshots/reference-platform/openembedded/jethro/stih410-b2260/rpb-wayland/latest/rpb-console-image-stih410-b2260-*.stimg)) |
+
+**Krogoth**
+
+|   SD Card image    |  Build Folder ([RPB](http://builds.96boards.org/snapshots/reference-platform/openembedded/krogoth/stih410-b2260/rpb/latest/)/[RPB-Wayland](http://builds.96boards.org/snapshots/reference-platform/openembedded/krogoth/stih410-b2260/rpb-wayland/latest/)) |
+|:------------------|:-----------------------|
+| RPB    | ([Desktop](http://builds.96boards.org/snapshots/reference-platform/openembedded/krogoth/stih410-b2260/rpb/latest/rpb-desktop-image-stih410-b2260-*.stimg)/[Console](http://builds.96boards.org/snapshots/reference-platform/openembedded/krogoth/stih410-b2260/rpb/latest/rpb-console-image-stih410-b2260-*.stimg)) |
+| RPB-Wayland | ([Desktop](http://builds.96boards.org/snapshots/reference-platform/openembedded/krogoth/stih410-b2260/rpb-wayland/latest/rpb-weston-image-stih410-b2260-*.stimg)/[Console](http://builds.96boards.org/snapshots/reference-platform/openembedded/krogoth/stih410-b2260/rpb-wayland/latest/rpb-console-image-stih410-b2260-*.stimg)) |
+
+Only download one SD card image (Either Jethro Console, Jethro Desktop, Krogoth Console or Krogoth Desktop).
+
+### Continue to [Installation page](../Installation/README.md)

--- a/Downloads/README.md
+++ b/Downloads/README.md
@@ -1,6 +1,6 @@
 ## Downloads
 
-The B2260 Development Board comes pre-installed with Debian LINUX distribution. If you would like to switch the Operating System, update the existing software images on your board, or unbrick your board, this page provides links to the latest software downloads.
+The B2260 Development Board comes pre-installed with Debian Linux distribution. If you would like to switch the Operating System, update the existing software images on your board, or unbrick your board, this page provides links to the latest software downloads.
 
 ***
 

--- a/GettingStarted/README.md
+++ b/GettingStarted/README.md
@@ -1,33 +1,35 @@
 # Getting Started
-Learn about your B2260 board as well as how to prepare and set up for basic use
+Learn about your B2260 board as well as how to prepare and set up for basic use.
 
-## Setup - What you will need
+## Setup - Hardware
 
-**Need**
+**Required**
 - [B2260](Insert B2260 96Boards.org landing page link here)
-   - Board based on the Cannes2-STiH410 Processor
+   - Board based on the Cannes2-STiH410 SoC
 - Power Supply
-   - 96Boards specifications requires a 12V / 5A Power supply ; Recommended : SUN-1200500 by SUNUP electronics.
-   -  a Jack adaptor ; Recommended :  https://www.96boards.org/products/accessories/power/
+   - 12V supply required, recommended minimum 2A
+   - For more info see: https://www.96boards.org/products/accessories/power/
 - USB Keyboard and Mouse
-   - With two USB-A connectors, all 96Boards can be equiped with
-   a full sized AZERTY keyboard and mouse
+   - 96board CE specification requires two USB-A connectors, thus all 96Boards can be simultaneously equipped with a keyboard and mouse without the need for an external USB hub
 - Monitor and HDMI Cable
-   -  96Board is  equiped with a full sized HDMI connector,
-   -  HDMI capable monitor or Standard TV, supported resolution up to 1080p60 is needed
-- MicroSD card  
-   - For booting board and for quick and easy switching between operating systems and extra storage. SDCard capacity is  2GB minimum.
+   -  96Boards are equiped with a full sized HDMI connector
+   -  HDMI capable monitors or TVs with resolutions up to 1080p60 are supported
+- MicroSD Card
+   - Used for storage and quick and easy switching between operating systems
+   - For standard Linaro images, SD cards are required to have be at least 4GB
 
 **Optional**
 - Ethernet cable
-   - For connecting to a network without using WiFi
+   - For connecting to networks without using WiFi
 - 96Boards UART Adapter Board
-   - For connecting to PC via serial link. Useful for debugging.
-   - Recommended : https://www.96boards.org/products/mezzanine/uarts/
+   - For connecting to PC via serial link (particuarlly useful for debugging the boot process)
+   - For more info see: https://www.96boards.org/products/mezzanine/uarts/
 
 ***
 # Out of the Box
-The following subsections should describe how to get started with the B2260 using the release build shipped with the boards. The B2260 board is ready to use “out of the box”  and delivered micro SDCard is populated by a preinstalled version of Debian Linux distribution.
+The following subsections describe how to get started with the B2260 using the release build shipped with the board.
+
+The B2260 is supplied with Micro SD card containig a preinstalled version of Debian, thus should be ready to use out-of-the-box.
 
 <img src="../AdditionalDocs/Images/ST_B2260_Front_SD.png" data-canonical-src="./AdditionalDocs/Images/ST_B2260_Front_SD.png" width="240" height="276" />
 <img src="../AdditionalDocs/Images/ST_B2260_Angle_SD.png" data-canonical-src="./AdditionalDocs/Images/ST_B2260_Angle_SD.png" width="276" height="240" />
@@ -37,46 +39,48 @@ The following subsections should describe how to get started with the B2260 usin
 
 |   Component          |   Description|
 |:---------------------|:-------------------------------------------------------------------------------------------------|
-|  SoC                 | Cannes2-STiH410 EJG|
+|  SoC                 | Cannes2-STiH410 EJG |
 |  CPU                 | Dual ARMcortex-A9 @ 1.5 GHz |
-|  GPU                 | ARM Mali 400 GPU @ 355 MHz|
-|  RAM                 | 2 x (DDR3 16-bit 500MB)|
-|  PMU                 | None|
-|  Storage             | MicroSD card slot , SPI NOR |
-|  Ethernet Port       | Up to 1 GB|
-|  Wireless            | Wi-Fi 802.11 g/n  , Bluetooth 4.0 LE|
-|  USB                 | 2 x USB2.0 Host (TypeA), 1x USB3.0 DRD Salve (Type micro AB), 1 x USB 2.0 host (on high-speed expansion connector)|
-|  Display             | 1 x HDMI 1.4 up to 1080p60 (TypeA)|
-|  Video               | Software video codecs|
-|  Audio               | outputs on HDMI and PCM/I2S (via Low-speed expansion connector)|
-|  Camera              | None|
-|  Expansion Interface | 40 pin Low-speed expansion connector (12 x GPIO, 1 UART 4 wires, 1 UART 2 wires, 2 x I2C, 1 PCM/I2S, 1 SPI, 1 Fan Ctrl, reset  button);  60 pin High-speed expansion connector (1x USB, 2 x I2C, 1x SPI, 1x SD interface) |
-|  LED                 | 1 x WiFi activity LED（Yellow）, 1 x BT activity LED (Blue),4 x User LEDs (Green)|
-|  Button              | Reset
-|  Power Source        | 12V , 5A, Plug specification is inner diameter 1.7mm and outer diameter 4.8mm |
-|  OS Support          | Linux based on Debian ; Linux based on OpenEmbedded|
-|  Size                | 85mm x 100mm|
+|  GPU                 | ARM Mali 400 GPU @ 355 MHz |
+|  RAM                 | 2 x (DDR3 16-bit 500MB) |
+|  PMU                 | None |
+|  Storage             | Built-in MicroSD card reader |
+|  Ethernet Port       | Up to 1 Gb/s |
+|  Wireless            | Wi-Fi 802.11 g/n, Bluetooth 4.0 LE |
+|  USB                 | 2 x USB2.0 Host (TypeA), 1x USB3.0 DRD Salve (Type micro AB), 1 x USB 2.0 host (on high-speed expansion connector) |
+|  Display             | 1 x HDMI 1.4 up to 1080p60 (TypeA) |
+|  Video               | Software video codecs |
+|  Audio               | HDMI and PCM/I2S (via Low-speed expansion connector) |
+|  Camera              | None |
+|  Expansion Interface | 40 pin Low-speed expansion connector (12 x GPIO, 1 UART 4 wires, 1 UART 2 wires, 2 x I2C, 1 PCM/I2S, 1 SPI, 1 fan ctrl, reset  button);  60 pin High-speed expansion connector (1x USB, 2 x I2C, 1x SPI, 1x SD interface) |
+|  LED                 | 1 x WiFi activity LED (yellow, 1 x BT activity LED (blue), 4 x User LEDs (green) |
+|  Button              | Reset |
+|  Power Source        | 12V, 2A (min), Plug specification is inner diameter 1.7mm and outer diameter 4.8mm |
+|  OS Support          | Linux based on Debian, Linux based on OpenEmbedded |
+|  Size                | 85mm x 100mm |
 
 **IMPORTANT NOTES**
-
 
 - HDMI EDID display data is used to determine the best display resolution. On monitors and TVs that support 1080p (or 1200p) this resolution will be selected. If 1080p is not supported the next available resolution reported by EDID will be used. This selected mode will work with most but not all monitors/TVs.
 ***
 
 ## Starting the board for the first time
-Micro SDCard comes preloaded with Debian Linux and can be up and running with a few simple steps:
+MicroSD card comes preloaded with Debian Linux and can be up and running with a few simple steps:
 
-- Connect the B2260 to your display with the HDMI cable. It is important to do this first because the monitor will not detect the board if it is connected after starting. Ensure that the source for the display is switched to the HDMI port you are using
-- Connect the USB keyboard and mouse using USB ports type A.
-- Insert the populated Micro SDCard the B2260.
+- Connect the B2260 to your display with the HDMI cable
+  - It is important to do this first because the monitor will not detect the board if it is connected after starting
+  - Ensure that the source for the display is switched to the HDMI port you are using
+- Connect the USB keyboard and mouse to the USB Type-A connectors
+- Insert the populated Micro SD card
 
 > Note: The above setup will cause B2260 Board to Auto Power up when it is plugged into power
 
-- Connect the power supply to the B2260. The board will begin to boot Debian Linux after **X (to be updated)** s.
+- Connect the power supply to the B2260
+  - The board will begin to boot Debian Linux after a few seconds
 
 ***
 
-## Updating to a new release or change your operating system
+## Updating to a new release or changing your Operating System
 
 <Do not touch this section>
 

--- a/HardwareDocs/README.md
+++ b/HardwareDocs/README.md
@@ -1,8 +1,6 @@
 # Hardware Documentation
 
-Explore what makes your B2260  Development Board unique, technical specifications, schematics, hardware notes and more... This page allows you to see what is under the "B2260 hood" by offering static documentation published directly from the board vendors.
-
 ## Hardware
 
-- BOM ([View](https://github.com/sdrobertw/B2260/blob/master/HardwareDocs/B2260_BOM.pdf) / [Download](https://github.com/sdrobertw/B2260/raw/master/HardwareDocs/B2260_BOM.pdf))
+- Bill of Materials (BoM) ([View](https://github.com/sdrobertw/B2260/blob/master/HardwareDocs/B2260_BOM.pdf) / [Download](https://github.com/sdrobertw/B2260/raw/master/HardwareDocs/B2260_BOM.pdf))
 - Schematics ([View](https://github.com/sdrobertw/B2260/blob/master/HardwareDocs/B2260_Schematics.pdf) / [Download](https://github.com/sdrobertw/B2260/raw/master/HardwareDocs/B2260_Schematics.pdf))

--- a/Installation/BoardRecovery.md
+++ b/Installation/BoardRecovery.md
@@ -1,5 +1,5 @@
 # B2260 Board Recovery
 
-< This page is extremely important and will vary for each 96Boards, if a user is confronted with a bricked (unusable) board, how might they go about fixing this? Other 96Boards Board Recovery example can be found
+< This page is extremely important and will vary for each 96Boards, if a user is confronted with a bricked (unusable) board, how might they go about fixing this? Other 96Boards Board Recovery example can be found >
 
 Not yet available

--- a/Installation/LinuxFastboot.md
+++ b/Installation/LinuxFastboot.md
@@ -1,2 +1,2 @@
 ## Linux Host
- Not Applicable => to be delete
+ Not Applicable => to be deleted

--- a/Installation/LinuxSD.md
+++ b/Installation/LinuxSD.md
@@ -1,13 +1,14 @@
 ## Linux Host
 
-This section show how to install an operating system to your B2260 using the SD Card method on a Linux host computer.
+This section describes the process for installing a new Operating System using the SD Card method on a Linux host machine.
+
 ***
 
 - **Step 1**: Prepare MicroSD card
 - **Step 2**: Find SD Card Device name
 - **Step 3**: Recall Download Location
 - **Step 4**: Unzip _SD Card Install Image_
-- **Step 5**: Go to directory with _SD Card Install Image_ folder using Terminal
+- **Step 5**: Go to directory with _SD Card Install Image_ directory via the commandline
 - **Step 6**: Locate SD Card Install Image
 - **Step 7**: Install Image onto SD Card
 - **Step 8**: Prepare B2260 with SD card
@@ -21,8 +22,7 @@ This section show how to install an operating system to your B2260 using the SD 
 
 ####**Step 2**: Find SD Card Device name
 
-- Use host computer
-- Open "Terminal" application
+- From the host computer open "Terminal" (or equivalent) application
 - Remove SD card from host computer and run the following command:
 ```shell
 $ lsblk
@@ -47,8 +47,7 @@ $ lsblk
 
 ####**Step 5**: Go to directory with _SD Card Install Image_ folder using Terminal
 
-- Use host computer
-- Open "Terminal" application
+- Open "Terminal" application on host machine
 - `cd` to the directory with your unzipped **SD Card Install Image**
 
 ```shell
@@ -79,7 +78,7 @@ b2260-jessie_developer_YYYYMMDD-X.img
 **Checklist:**
 
 - SD card inserted into host computer
-- Recall SD Card device name from [**Step 2**]()
+- Recall SD card device name from [**Step 2**]()
 - Using the Terminal to copy b2260-jessie_developer_YYYYMMDD-X.img image file into SD card by running the following commands:
 
 **Execute:**
@@ -94,7 +93,8 @@ $ sudo sync
 - `if=b2260-jessie_developer_YYYYMMDD-X.img`: should match the name of the image that was downloaded.
 - `of=/dev/XXX`: XXX should match the name of the SD Card device name from **Step 2**. Be sure to use the device name without the partition name. For example, 'of=/dev/disk1'
 - If you get an error message "Resource Busy", you will need to unmount the SD card without removing it from the host computer.
-Option 1:
+
+  Option 1:
   - In the Applications folder, find and click on the Utilities folder.
   - Click on the Disk Utility program to run it
   - Select the device that represents the SD card
@@ -107,15 +107,15 @@ Option 1:
 $ sudo umount /dev/<device name>
 ```
 
-- This command will take some time to execute few minutes). Be patient and avoid tampering with the terminal until process has ended.
-- Once SD card is done flashing, remove from host computer and set aside for **Step 8** You may see a popup window that tells you the device is _Not readable by the operating system_. Ignore the message and remove the MicroSD card from the host computer.
+- This command will take some time to execute (a few minutes). Be patient and avoid tampering with the terminal until process has ended.
+- Once SD card is done flashing, remove from host computer and set aside for **Step 8**. You may see a popup window that tells you the device is _Not readable by the operating system_. Ignore the message and remove the MicroSD card from the host computer.
 
 ####**Step 8**: Prepare B2260 with SD card
 
-- Make sure B2260 is unplugged from power
+- Make sure B2260 is powered off
 - Connect an HDMI monitor to the B2260 with an HDMI cable, and power on the monitor
 - Plug a USB keyboard and/or mouse into either of the two USB connectors on the B2260
 - Insert the microSD card into the B2260
-- Plug power adaptor into B2260, wait for board to boot up.
+- Apply power to B2260, wait for board to boot
 
 **Congratulations! You are now booting your newly installed operating system directly from SD card on the B2260!**

--- a/Installation/README.md
+++ b/Installation/README.md
@@ -1,6 +1,6 @@
 # Installation
 
-Choose and install an operating system on your B2260. To appropriately follow this installation guide you will need to:
+Choose and install an Operating System on your B2260. To appropriately follow this installation guide you will need to:
 
 - Choose an installation method
 - Download necessary files
@@ -11,23 +11,20 @@ Choose and install an operating system on your B2260. To appropriately follow th
 
 ## Methods of Installation
 
-In most cases, you will be presented with two options when installing your new operating system onto your B2260:
+Installation via microSD card is currently the only supported method.
 
-- SD Card Method
+### MicroSD Card Method
 
-Each method has it's own benifits, and requires different levels of experience
+This method allows you to place a microSD card into the B2260 and automatically boot your board.
 
-### SD Card Method
+Required hardware:
 
-The SD card method allows you to place a microSD card into a B2260 to automatically boot your board.
-
-This method requires the following hardware:
-
-- B2260 with power supply,
-- Host machine (Linux, Mac OS X, or Windows),
-- MicroSD card with 4GB or more of storage,
-- USB Mouse and keyboard,
-- HDMI Monitor with full size HDMI cable,
+- B2260
+- Power supply
+- Host machine (Linux, Mac OS X or Windows)
+- MicroSD card (4GB minimum)
+- USB mouse and keyboard
+- HDMI monitor and cable
 
 Go to the [Downloads page](../Downloads/README.md) to get your SD card image.
 


### PR DESCRIPTION
Overhaul of the B2260 documentation.

- Removing unused pages/sections
- Add "Download" links to newly available images
- Standardising terms and layout
- Supply new OpenEmbedded Download page
- General tidy-up